### PR TITLE
clarify two-factor email equality rules

### DIFF
--- a/app/Enums/TwoFaResult.php
+++ b/app/Enums/TwoFaResult.php
@@ -6,9 +6,11 @@ enum TwoFaResult: string
 {
     case TWO_FA_DELETE = 'TWO_FA_DELETE'; // Löschen der 2-FA-Authentifizieren
     case TWO_FA_OK = 'TWO_FA_OK'; // Zwei-Faktoren-Authenifizierung ok, 2-FA-E-Mail vorhanden und verifiziert
-    case TWO_FA_EMAIL_MUST_BE_VERIFIED = 'TWO_FA_EMAIL_MUST_BE_VERIFIED'; // 2FA-EMail exists, but isnt verified at this moment => must be verified
+    // 2FA-EMail exists, but isnt verified at this moment
+    case TWO_FA_EMAIL_MUST_BE_VERIFIED = 'TWO_FA_EMAIL_MUST_BE_VERIFIED';
     case TWO_FA_EMAIL_IS_NEW = 'TWO_FA_EMAIL_IS_NEW'; // 2FA-EMail is new and not verified
-    case TWO_FA_EMAIL_AND_2FA_EMAIL_MUST_NOT_BE_EQUAL = 'TWO_FA_EMAIL_AND_2FA_EMAIL_MUST_NOT_BE_EQUAL';  //
+    // Fehler, wenn 2-FA-E-Mail und Benutzer-E-Mail gleich sind
+    case TWO_FA_EMAIL_AND_2FA_EMAIL_MUST_NOT_BE_EQUAL = 'TWO_FA_EMAIL_AND_2FA_EMAIL_MUST_NOT_BE_EQUAL';
     case TWO_FA_ERROR = 'TWO_FA_ERROR';  // 2FA-ERROR
     case TWO_FA_SET = 'TWO_FA_SET';  // 2FA is set now
 

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -103,7 +103,7 @@ class UserService
 
         // ** 2-FA-WANTED ...
 
-        // 2-FA-E-Mail is the same, as the user entered and is verified => everything ok
+        // Die 2-FA-E-Mail darf nicht mit der Standard-E-Mail identisch sein
         if ($email_2fa == $user->email) {
             return TwoFaResult::TWO_FA_EMAIL_AND_2FA_EMAIL_MUST_NOT_BE_EQUAL;
         }


### PR DESCRIPTION
## Summary
- document that 2FA email must differ from standard email
- explain enum result when 2FA and user emails match

## Testing
- `php artisan test`
- `./vendor/bin/pest`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688e2a859f4c832290f7345a810cb67a