### PR TITLE
Add detailed AdminController feature tests

### DIFF
--- a/tests/Feature/Controller/Admin/AdminController/ConfigTest.php
+++ b/tests/Feature/Controller/Admin/AdminController/ConfigTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use function Pest\Laravel\getJson;
+
+it('returns configuration data with menu', function () {
+    $menu = ['dashboard'];
+
+    Mockery::mock('overload:App\\Services\\AdminNavigationService')
+        ->shouldReceive('dashboardMenu')
+        ->once()
+        ->andReturn($menu);
+
+    $response = getJson('/api/admin/config');
+
+    $response->assertStatus(200)
+        ->assertJson(['menu' => $menu, 'is_auth' => false])
+        ->assertJsonStructure([
+            'logo',
+            'copyright',
+            'title',
+            'company',
+            'version',
+            'register_admin_allowed',
+            'timeout',
+            'is_auth',
+            'user',
+            'menu',
+        ]);
+})->runInSeparateProcess();

--- a/tests/Feature/Controller/Admin/AdminController/ExecuteLogoutTest.php
+++ b/tests/Feature/Controller/Admin/AdminController/ExecuteLogoutTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\postJson;
+use Illuminate\Support\Facades\Auth;
+
+it('logs out authenticated user', function () {
+    actingAs($this->admin);
+
+    $response = postJson('/api/admin/execute_logout');
+
+    $response->assertStatus(200)
+        ->assertJson(['message' => 'Logout successful']);
+
+    expect(Auth::check())->toBeFalse();
+});

--- a/tests/Feature/Controller/Admin/AdminController/LoginStep1Test.php
+++ b/tests/Feature/Controller/Admin/AdminController/LoginStep1Test.php
@@ -1,0 +1,20 @@
+<?php
+
+use function Pest\Laravel\postJson;
+
+it('prompts for password after email', function () {
+    Mockery::mock('overload:App\\Services\\AdminService')
+        ->shouldReceive('checkUserLogin')
+        ->once()
+        ->andReturn($this->admin);
+
+    $payload = ['data' => [
+        'step' => 'LOGIN_ENTER_EMAIL',
+        'email' => $this->admin->email,
+    ]];
+
+    $response = postJson('/api/admin/login_step_1', $payload);
+
+    $response->assertStatus(200)
+        ->assertJson(['step' => 'LOGIN_ENTER_PASSWORD']);
+})->runInSeparateProcess();

--- a/tests/Feature/Controller/Admin/AdminController/LoginStep2Test.php
+++ b/tests/Feature/Controller/Admin/AdminController/LoginStep2Test.php
@@ -1,0 +1,48 @@
+<?php
+
+use function Pest\Laravel\postJson;
+use Illuminate\Support\Facades\Auth;
+
+it('logs in user without 2fa', function () {
+    Mockery::mock('overload:App\\Services\\AdminService')
+        ->shouldReceive('checkUserLogin')
+        ->once()
+        ->andReturn($this->admin);
+
+    $payload = ['data' => [
+        'step' => 'LOGIN_ENTER_PASSWORD',
+        'email' => $this->admin->email,
+        'password' => 'secret123',
+    ]];
+
+    $response = postJson('/api/admin/login_step_2', $payload);
+
+    $response->assertStatus(200)
+        ->assertJson(['step' => 'LOGIN_SUCCESS', 'auth' => true])
+        ->assertJsonPath('user.id', $this->admin->id);
+
+    expect(Auth::check())->toBeTrue();
+})->runInSeparateProcess();
+
+it('requires token when 2fa enabled', function () {
+    $user = $this->admin;
+    $user->is_2fa = true;
+
+    Mockery::mock('overload:App\\Services\\AdminService', function ($mock) use ($user) {
+        $mock->shouldReceive('checkUserLogin')->once()->andReturn($user);
+        $mock->shouldReceive('continueLoginFor2FaUser')->once()->with($user);
+    });
+
+    $payload = ['data' => [
+        'step' => 'LOGIN_ENTER_PASSWORD',
+        'email' => $user->email,
+        'password' => 'secret123',
+    ]];
+
+    $response = postJson('/api/admin/login_step_2', $payload);
+
+    $response->assertStatus(200)
+        ->assertJson(['step' => 'LOGIN_ENTER_TOKEN']);
+
+    expect(Auth::check())->toBeFalse();
+})->runInSeparateProcess();

--- a/tests/Feature/Controller/Admin/AdminController/LoginStep3Test.php
+++ b/tests/Feature/Controller/Admin/AdminController/LoginStep3Test.php
@@ -1,0 +1,29 @@
+<?php
+
+use function Pest\Laravel\postJson;
+use Illuminate\Support\Facades\Auth;
+
+it('completes login after valid token', function () {
+    $user = $this->admin;
+    $user->is_2fa = true;
+
+    Mockery::mock('overload:App\\Services\\AdminService')
+        ->shouldReceive('checkUserLogin')
+        ->once()
+        ->andReturn($user);
+
+    $payload = ['data' => [
+        'step' => 'LOGIN_ENTER_TOKEN',
+        'email' => $user->email,
+        'password' => 'secret123',
+        'token_2fa' => '123456',
+    ]];
+
+    $response = postJson('/api/admin/login_step_3', $payload);
+
+    $response->assertStatus(200)
+        ->assertJson(['step' => 'LOGIN_SUCCESS', 'auth' => true])
+        ->assertJsonPath('user.id', $user->id);
+
+    expect(Auth::check())->toBeTrue();
+})->runInSeparateProcess();

--- a/tests/Feature/Controller/Admin/AdminController/PasswordUnknownStep1Test.php
+++ b/tests/Feature/Controller/Admin/AdminController/PasswordUnknownStep1Test.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Models\User;
+use function Pest\Laravel\postJson;
+
+it('sends reset token on password unknown step1', function () {
+    $user = User::factory()->make(['email' => 'reset@example.com']);
+
+    Mockery::mock('overload:App\\Services\\AdminService', function ($mock) use ($user) {
+        $mock->shouldReceive('checkPasswordUnknown')->once()->andReturn($user);
+        $mock->shouldReceive('sendPasswordResetToken')->once()->with(1, $user, 'reset@example.com');
+    });
+
+    $payload = ['data' => [
+        'step' => 'PASSWORD_UNKNOWN_ENTER_EMAIL',
+        'email' => 'reset@example.com',
+    ]];
+
+    $response = postJson('/api/admin/password_unknown_step_1', $payload);
+
+    $response->assertStatus(200)
+        ->assertJson(['step' => 'PASSWORD_UNKNOWN_ENTER_TOKEN']);
+})->runInSeparateProcess();

--- a/tests/Feature/Controller/Admin/AdminController/PasswordUnknownStep2Test.php
+++ b/tests/Feature/Controller/Admin/AdminController/PasswordUnknownStep2Test.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\User;
+use function Pest\Laravel\postJson;
+
+it('completes reset when user has no 2fa', function () {
+    $user = User::factory()->make(['is_2fa' => false, 'email' => 'reset@example.com']);
+
+    Mockery::mock('overload:App\\Services\\AdminService')
+        ->shouldReceive('checkPasswordUnknown')
+        ->once()
+        ->andReturn($user);
+
+    $payload = ['data' => [
+        'step' => 'PASSWORD_UNKNOWN_ENTER_TOKEN',
+        'email' => 'reset@example.com',
+        'token_2fa' => '123456',
+    ]];
+
+    $response = postJson('/api/admin/password_unknown_step_2', $payload);
+
+    $response->assertStatus(200)
+        ->assertJson(['step' => 'PASSWORD_UNKNOWN_SUCCESS']);
+})->runInSeparateProcess();
+
+it('sends second token when user has 2fa enabled', function () {
+    $user = User::factory()->make(['is_2fa' => true, 'email' => 'twofa@example.com', 'email_2fa' => 'backup@example.com']);
+
+    Mockery::mock('overload:App\\Services\\AdminService', function ($mock) use ($user) {
+        $mock->shouldReceive('checkPasswordUnknown')->once()->andReturn($user);
+        $mock->shouldReceive('sendPasswordResetToken')->once()->with(2, $user, 'backup@example.com');
+    });
+
+    $payload = ['data' => [
+        'step' => 'PASSWORD_UNKNOWN_ENTER_TOKEN',
+        'email' => 'twofa@example.com',
+        'token_2fa' => '123456',
+    ]];
+
+    $response = postJson('/api/admin/password_unknown_step_2', $payload);
+
+    $response->assertStatus(200)
+        ->assertJson(['step' => 'PASSWORD_UNKNOWN_ENTER_TOKEN_2']);
+})->runInSeparateProcess();

--- a/tests/Feature/Controller/Admin/AdminController/PasswordUnknownStep3Test.php
+++ b/tests/Feature/Controller/Admin/AdminController/PasswordUnknownStep3Test.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Models\User;
+use function Pest\Laravel\postJson;
+
+it('prompts for new password after tokens', function () {
+    $user = User::factory()->make(['is_2fa' => true, 'email' => 'twofa@example.com']);
+
+    Mockery::mock('overload:App\\Services\\AdminService')
+        ->shouldReceive('checkPasswordUnknown')
+        ->once()
+        ->andReturn($user);
+
+    $payload = ['data' => [
+        'step' => 'PASSWORD_UNKNOWN_ENTER_TOKEN_2',
+        'email' => 'twofa@example.com',
+        'token_2fa' => '123456',
+        'token_2fa_2' => '654321',
+    ]];
+
+    $response = postJson('/api/admin/password_unknown_step_3', $payload);
+
+    $response->assertStatus(200)
+        ->assertJson(['step' => 'PASSWORD_UNKNOWN_ENTER_PASSWORD']);
+})->runInSeparateProcess();

--- a/tests/Feature/Controller/Admin/AdminController/PasswordUnknownStep4Test.php
+++ b/tests/Feature/Controller/Admin/AdminController/PasswordUnknownStep4Test.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Models\User;
+use function Pest\Laravel\postJson;
+
+it('resets password and finishes process', function () {
+    $user = Mockery::mock(User::class);
+    $user->shouldReceive('setPassword')->once()->with('newpassword');
+
+    Mockery::mock('overload:App\\Services\\AdminService')
+        ->shouldReceive('checkPasswordUnknown')
+        ->once()
+        ->andReturn($user);
+
+    $payload = ['data' => [
+        'step' => 'PASSWORD_UNKNOWN_ENTER_PASSWORD',
+        'email' => 'reset@example.com',
+        'token_2fa' => '123456',
+        'password' => 'newpassword',
+        'password_repeat' => 'newpassword',
+    ]];
+
+    $response = postJson('/api/admin/password_unknown_step_4', $payload);
+
+    $response->assertStatus(200)
+        ->assertJson(['step' => 'PASSWORD_UNKNOWN_FINISHED']);
+})->runInSeparateProcess();

--- a/tests/Feature/Controller/Admin/AdminController/README.md
+++ b/tests/Feature/Controller/Admin/AdminController/README.md
@@ -1,0 +1,3 @@
+These feature tests exercise each public method of the `AdminController`.
+Each test file is named after its corresponding controller method and runs in a
+separate process to isolate Mockery's class overloading.

--- a/tests/Feature/Controller/Admin/AdminController/RegisterStep1Test.php
+++ b/tests/Feature/Controller/Admin/AdminController/RegisterStep1Test.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Models\User;
+use function Pest\Laravel\postJson;
+
+it('creates user and sends token on register step1', function () {
+    $user = User::factory()->make();
+
+    Mockery::mock('overload:App\\Services\\AdminService', function ($mock) use ($user) {
+        $mock->shouldReceive('checkRegister')->once()->andReturn(null);
+        $mock->shouldReceive('createRegisterUser')->once()->andReturn($user);
+        $mock->shouldReceive('sendRegisterToken')->once()->with(1, $user, 'new@example.com');
+    });
+
+    $payload = ['data' => [
+        'step' => 'REGISTER_ENTER_EMAIL',
+        'email' => 'new@example.com',
+    ]];
+
+    $response = postJson('/api/admin/register_step_1', $payload);
+
+    $response->assertStatus(200)
+        ->assertJson(['step' => 'REGISTER_ENTER_TOKEN']);
+})->runInSeparateProcess();

--- a/tests/Feature/Controller/Admin/AdminController/RegisterStep2Test.php
+++ b/tests/Feature/Controller/Admin/AdminController/RegisterStep2Test.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Models\User;
+use function Pest\Laravel\postJson;
+use Illuminate\Support\Carbon;
+
+it('verifies email and moves to field entry on register step2', function () {
+    $user = User::factory()->create(['email' => 'verify@example.com', 'email_verified_at' => null]);
+
+    Mockery::mock('overload:App\\Services\\AdminService')
+        ->shouldReceive('checkRegister')
+        ->once()
+        ->andReturn($user);
+
+    $payload = ['data' => [
+        'step' => 'REGISTER_ENTER_TOKEN',
+        'email' => 'verify@example.com',
+        'token_2fa' => '123456',
+    ]];
+
+    $response = postJson('/api/admin/register_step_2', $payload);
+
+    $response->assertStatus(200)
+        ->assertJson(['step' => 'REGISTER_ENTER_FIELDS']);
+
+    expect($user->refresh()->email_verified_at)->not->toBeNull();
+})->runInSeparateProcess();

--- a/tests/Feature/Controller/Admin/AdminController/RegisterStep3Test.php
+++ b/tests/Feature/Controller/Admin/AdminController/RegisterStep3Test.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Models\User;
+use function Pest\Laravel\postJson;
+use Illuminate\Support\Carbon;
+
+it('updates user details and finishes registration', function () {
+    $user = User::factory()->create(['email' => 'final@example.com', 'confirmed_at' => now()]);
+
+    Mockery::mock('overload:App\\Services\\AdminService', function ($mock) use ($user) {
+        $mock->shouldReceive('checkRegister')->once()->andReturn($user);
+        $mock->shouldReceive('updateRegisterUser')->once()->andReturn($user);
+    });
+
+    $payload = ['data' => [
+        'step' => 'REGISTER_ENTER_FIELDS',
+        'email' => 'final@example.com',
+        'token_2fa' => '123456',
+        'last_name' => 'Doe',
+        'first_name' => 'John',
+        'password' => 'secret123',
+        'password_repeat' => 'secret123',
+    ]];
+
+    $response = postJson('/api/admin/register_step_3', $payload);
+
+    $response->assertStatus(200)
+        ->assertJson(['step' => 'REGISTER_FINISHED']);
+})->runInSeparateProcess();


### PR DESCRIPTION
## Summary
- create AdminController feature test suite with separate files for config, authentication, registration and password reset flows
- document test suite structure and isolation approach

## Testing
- `composer install --no-progress --no-scripts --no-interaction` *(fails: Source path "../mediamanager" is not found for package itstudioat/mediamanager)*
- `composer test` *(fails: Failed opening required '/workspace/hpm/vendor/autoload.php')*
- `./vendor/bin/pint --test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfe0d72888322a881a5d83fe86c24